### PR TITLE
confusion and bars

### DIFF
--- a/vaalikone.Rproj
+++ b/vaalikone.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Adds bars to party table and sketches drawing a confusion matrix. What should be done is to edit function "confusion" that now sets a random 21x21 matrix. It should return the confusion when classifying the candidate data using the specified metrics. party acronyms should be used as matrix dimension labels. The row should contain the real party and the column the predicted party